### PR TITLE
Add Codex support for skills

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "elixir-phoenix-guide",
+  "version": "2.3.1",
+  "description": "Essential Elixir and Phoenix LiveView development guide with skills and patterns for idiomatic code",
+  "author": {
+    "name": "Joseph Morgan",
+    "url": "https://github.com/j-morgan6"
+  },
+  "homepage": "https://github.com/j-morgan6/elixir-phoenix-guide",
+  "repository": "https://github.com/j-morgan6/elixir-phoenix-guide",
+  "license": "MIT",
+  "keywords": [
+    "elixir",
+    "phoenix",
+    "liveview",
+    "ecto",
+    "optimization",
+    "best-practices"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Elixir Phoenix Guide",
+    "shortDescription": "Elixir and Phoenix development guidance for Codex",
+    "longDescription": "Skills for idiomatic Elixir, Phoenix LiveView, Ecto, OTP, Oban, testing, security, deployment, channels, telemetry, and JSON API work in Codex.",
+    "developerName": "Joseph Morgan",
+    "category": "Engineering",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/j-morgan6/elixir-phoenix-guide",
+    "brandColor": "#4B275F",
+    "defaultPrompt": [
+      "Review this Phoenix change",
+      "Build a LiveView feature",
+      "Fix this Ecto changeset"
+    ],
+    "screenshots": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .vscode/
 .idea/
 
+# Python virtual environments
+.venv/
+
 # Temporary files
 *.tmp
 *.bak

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Elixir Phoenix Guide for Claude Code
+# Elixir Phoenix Guide for Claude Code and Codex
 
 **Version:** 2.3.1 | [Changelog](CHANGELOG.md)
 
-An essential development guide for Claude Code that ensures idiomatic Elixir and Phoenix LiveView code. This plugin includes enforced skills, context-aware hooks, automated code quality analysis, and agent documentation that actively guide and validate your Elixir development workflow.
+An essential development guide for Claude Code and Codex that ensures idiomatic Elixir and Phoenix LiveView code. This plugin includes enforced skills, context-aware hooks for Claude Code, automated code quality analysis, and agent documentation that actively guide and validate your Elixir development workflow.
 
 > **v2.3.1 Released!** Corrected LiveView assigns and test setup guidance based on community feedback. See [CHANGELOG.md](CHANGELOG.md) for details.
 
@@ -95,6 +95,18 @@ Detailed reference material for complex tasks:
 ## Installation
 
 > **Note:** Official marketplace publication is in progress. Once available, installation will be even simpler through the official Claude Code marketplace.
+
+### Codex
+
+To install the skills for the current Codex user:
+
+```bash
+./install-codex.sh
+```
+
+This copies all skill directories into `${CODEX_HOME:-~/.codex}/skills`. Restart Codex after installation so the skills are discovered.
+
+This repository also includes a Codex plugin manifest at `.codex-plugin/plugin.json` for plugin-based discovery.
 
 ### Installing for the First Time
 

--- a/install-codex.sh
+++ b/install-codex.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}Installing Elixir Phoenix Guide for Codex${NC}"
+echo "========================================="
+echo ""
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+CODEX_SKILLS_DIR="$CODEX_HOME/skills"
+
+if [ ! -d "$SOURCE_DIR/skills" ]; then
+  echo -e "${RED}Error: skills directory not found at $SOURCE_DIR/skills${NC}"
+  exit 1
+fi
+
+echo -e "${YELLOW}Installing skills into $CODEX_SKILLS_DIR...${NC}"
+mkdir -p "$CODEX_SKILLS_DIR"
+
+SKILL_COUNT=0
+for skill_dir in "$SOURCE_DIR/skills"/*; do
+  if [ -d "$skill_dir" ] && [ -f "$skill_dir/SKILL.md" ]; then
+    skill_name="$(basename "$skill_dir")"
+    mkdir -p "$CODEX_SKILLS_DIR/$skill_name"
+    cp "$skill_dir/SKILL.md" "$CODEX_SKILLS_DIR/$skill_name/SKILL.md"
+    SKILL_COUNT=$((SKILL_COUNT + 1))
+  fi
+done
+
+echo -e "${GREEN}Installed $SKILL_COUNT Codex skills${NC}"
+echo ""
+echo "Installed to: $CODEX_SKILLS_DIR"
+echo -e "${YELLOW}Restart Codex to pick up the new skills.${NC}"


### PR DESCRIPTION
## Summary

Adds Codex support alongside the existing Claude Code setup.

- Adds a Codex plugin manifest pointing to the existing `skills/` directory
- Adds `install-codex.sh` to install skills into `~/.codex/skills`
- Documents Codex installation in the README
- Ignores local Python virtual environments used for validation

## Notes

This does not port Claude Code hooks to Codex. The Codex support added here is focused on skill discovery and installation.

Review packet for reference: https://reviews.figitaki.dev/r/CumQzF3q

## Validation

- Ran the Codex plugin validator successfully
- Installed all 19 skills into `~/.codex/skills`